### PR TITLE
this fixes user_file not being loaded when cwd is under home dir and contains a config file.

### DIFF
--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -121,7 +121,7 @@ sub load_global {
 sub user_file {
     my $self = shift;
     return
-        File::Spec->catfile( "~", "." . $self->confname );
+        File::Spec->catfile( $ENV{'HOME'}, "." . $self->confname );
 }
 
 sub load_user {


### PR DESCRIPTION
load_user is testing unexpanded user_file (with ~) so it never worked,
which seems to be covered by load_dirs in most cases.
