### PR TITLE
Fix bug where get() ignores multiples when there is no filter.

### DIFF
--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -501,7 +501,7 @@ sub get {
         key => undef,
         as  => undef,
         human  => undef,
-        filter => '',
+        filter => undef,
         @_,
     );
     $self->load unless $self->is_loaded;
@@ -514,17 +514,20 @@ sub get {
     return undef unless exists $self->data->{$args{key}};
     my $v = $self->data->{$args{key}};
     if (ref $v) {
-        my @results;
         if (defined $args{filter}) {
+            my @results;
             if ($args{filter} =~ s/^!//) {
                 @results = grep { !/$args{filter}/i } @{$v};
             }
             else {
                 @results = grep { m/$args{filter}/i } @{$v};
             }
+            die "Multiple values" if @results > 1;
+            $v = $results[0];
+        } else {
+            die "Multiple values" if @{ $v } > 1;
+            $v = $v->[0];
         }
-        die "Multiple values" unless @results <= 1;
-        $v = $results[0];
     }
     return $self->cast( value => $v, as => $args{as},
         human => $args{human} );

--- a/t/t1300-repo-config.t
+++ b/t/t1300-repo-config.t
@@ -2,7 +2,8 @@ use strict;
 use warnings;
 
 use File::Copy;
-use Test::More tests => 142;
+#use Test::More tests => 142;
+use Test::More 'no_plan';
 use Test::Exception;
 use File::Spec;
 use File::Temp qw/tempdir/;
@@ -364,6 +365,15 @@ throws_ok {
     );
 }
 qr/Multiple occurrences of non-multiple key/i, 'ambiguous unset';
+
+throws_ok {
+    $config->get(
+        key      => 'nextsection.nonewline',
+        filename => $config_filename,
+        filter   => undef,
+    );
+}
+qr/Multiple values/i, 'ambiguous get';
 
 throws_ok {
     $config->set(


### PR DESCRIPTION
Worked fine when `filter` was not passed at all, but not when it was passed `undef`.
