### PR TITLE
Eliminate "use of uninitialized value" warnings.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,7 @@ repository('http://github.com/bestpractical/config-gitlike');
 perl_version '5.008';
 requires 'Any::Moose';
 build_requires 'Test::Exception';
+build_requires 'Test::NoWarnings';
 extra_tests();
 sign();
 WriteAll();

--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -505,9 +505,12 @@ sub _get {
     $self->load unless $self->is_loaded;
 
     my ($section, $subsection, $name) = _split_key($args{key});
-    $args{key} = join( '.',
-        grep { defined } (lc $section, $subsection, lc $name),
-    );
+    $args{key} = do {
+        no warnings 'uninitialized';
+        join( '.',
+            grep { defined } (lc $section, $subsection, lc $name),
+        );
+    };
 
     return () unless exists $self->data->{$args{key}};
     my $v = $self->data->{$args{key}};

--- a/t/t1300-repo-config.t
+++ b/t/t1300-repo-config.t
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 
 use File::Copy;
-use Test::More tests => 142;
+use Test::More tests => 144;
 use Test::Exception;
+use Test::NoWarnings;
 use File::Spec;
 use File::Temp qw/tempdir/;
 use lib 't/lib';
@@ -271,6 +272,7 @@ is( slurp($config_filename), $expect, 'really really mean test' );
 
 $config->load;
 is( $config->get( key => 'beta.haha' ), 'alpha', 'get value' );
+is( $config->get( key => 'beta' ), undef, 'get nonexistent value' );
 
 # unset beta.haha (unset accomplished by value = undef)
 $config->set( key => 'beta.haha', filename => $config_filename );


### PR DESCRIPTION
All it takes is for someone to try to access a simple value like "foo", which
is parsed as a section having no name.

All well and good, but if I try it in Git, I get:

```
> git config foo
error: key does not contain a section: foo
```

So mabye Config::GitLike should throw an exception, instead?
