### PR TITLE
Add the "encoding" attribute and use it.

### DIFF
--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -58,6 +58,11 @@ has 'cascade' => (
     default => 0,
 );
 
+has 'encoding' => (
+    is => 'rw',
+    isa => 'Maybe[Str]',
+);
+
 sub set_multiple {
     my $self = shift;
     my ($name, $mult) = (@_, 1);
@@ -135,6 +140,9 @@ sub _read_config {
 
     return unless -f $filename and -r $filename;
     open(my $fh, '<', $filename) or return;
+    if (my $encoding = $self->encoding) {
+        binmode $fh, ":encoding($encoding)";
+    }
 
     my $c = do {local $/; <$fh>};
 
@@ -1007,6 +1015,9 @@ sub _write_config {
     # way git does it)
     sysopen(my $fh, "${filename}.lock", O_CREAT|O_EXCL|O_WRONLY)
         or die "Can't open ${filename}.lock for writing: $!\n";
+    if (my $encoding = $self->encoding) {
+        binmode $fh, ":encoding($encoding)";
+    }
     print $fh $content;
     close $fh;
 
@@ -1348,6 +1359,11 @@ If you wish to enforce only being able to read/write config files that
 git can read or write, pass in C<compatible =E<gt> 1> to this
 constructor. The default rules for some components of the config
 file are more permissive than git's (see L<"DIFFERENCES FROM GIT-CONFIG">).
+
+If you know that your Git config files are encoded with a known character
+encoding, pass in C<encoding =E<gt> $encoding> to specify the name of the
+encoding. Config::GitLike will then properly serialize and deserialized the
+files with that encoding.
 
 =head2 confname
 

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Spec;
+use File::Temp qw/tempdir/;
+use lib 't/lib';
+use TestConfig;
+
+my $config_dirname = tempdir( CLEANUP => !$ENV{CONFIG_GITLIKE_DEBUG} );
+my $config_filename = File::Spec->catfile( $config_dirname, 'config' );
+
+diag "config file is: $config_filename" if $ENV{TEST_VERBOSE};
+
+my $config = TestConfig->new(
+    confname => 'config',
+    tmpdir => $config_dirname,
+    encoding => 'UTF-8',
+);
+$config->load;
+
+UTF8: {
+    use utf8;
+    $config->set(
+        key      => 'core.penguin',
+        value    => 'little blüe',
+        filename => $config_filename
+    );
+}
+
+my $expect = qq{[core]\n\tpenguin = little blüe\n};
+is( slurp($config_filename), $expect, 'Value with UTF-8' );
+
+$config->load;
+UTF8: {
+    use utf8;
+    is $config->get(key => 'core.penguin'), 'little blüe',
+        'Get value with UTF-8';;
+}
+
+
+done_testing;
+
+sub slurp {
+    my $file = shift;
+    local ($/);
+    open( my $fh, $file ) or die "Unable to open file ${file}: $!";
+    return <$fh>;
+}


### PR DESCRIPTION
To encode and decode config files. Necessary because, if no encoding is
specified, and a UTF-8 string is saved to a config file, when it is read back
in, it will not be properly read as UTF-8. The same would go for any coding
other than Latin-1 (maybe).

I'm not sure what encoding Git assumes; perhaps the locale-specified encoding.
If so, perhaps we should set the file layters to `:locale` if no encoding
is specified?
