### PR TITLE
Switch to Moo.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,8 @@ all_from('lib/Config/GitLike.pm');
 repository('http://github.com/bestpractical/config-gitlike');
 
 perl_version '5.008';
-requires 'Any::Moose';
+requires 'Moo';
+requires 'MooX::Types::MooseLike';
 build_requires 'Test::Exception';
 extra_tests();
 sign();

--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -1,5 +1,6 @@
 package Config::GitLike;
-use Any::Moose;
+use Moo;
+use MooX::Types::MooseLike::Base qw(Bool HashRef ArrayRef Maybe Str);
 
 use File::Spec;
 use Cwd;
@@ -13,7 +14,7 @@ our $VERSION = '1.10';
 has 'confname' => (
     is => 'rw',
     required => 1,
-    isa => 'Str',
+    isa => Str,
 );
 
 # not defaulting to {} allows the predicate is_loaded
@@ -21,32 +22,32 @@ has 'confname' => (
 has 'data' => (
     is => 'rw',
     predicate => 'is_loaded',
-    isa => 'HashRef',
+    isa => HashRef,
 );
 
 # key => bool
 has 'multiple' => (
     is => 'rw',
-    isa => 'HashRef',
+    isa => HashRef,
     default => sub { +{} },
 );
 
 has 'casing' => (
     is => 'rw',
-    isa => 'HashRef',
+    isa => HashRef,
     default => sub { +{} },
 );
 
 # filename where the definition of each key was loaded from
 has 'origins' => (
     is => 'rw',
-    isa => 'HashRef',
+    isa => HashRef,
     default => sub { +{} },
 );
 
 has 'config_files' => (
     is => 'rw',
-    isa => 'ArrayRef',
+    isa => ArrayRef,
     default => sub { [] },
 );
 
@@ -54,19 +55,19 @@ has 'config_files' => (
 # of only-write-things-that-git-config-can-read if you want to
 has 'compatible' => (
     is => 'rw',
-    isa => 'Bool',
-    default => 0,
+    isa => Bool,
+    default => sub { 0 },
 );
 
 has 'cascade' => (
     is => 'rw',
-    isa => 'Bool',
-    default => 0,
+    isa => Bool,
+    default => sub { 0 },
 );
 
 has 'encoding' => (
     is => 'rw',
-    isa => 'Maybe[Str]',
+    isa => Maybe[Str],
 );
 
 sub set_multiple {
@@ -1319,7 +1320,7 @@ written by git. The converse is usually true, but only if you don't take
 advantage of this module's increased permissiveness when it comes to key
 names. (See L<DIFFERENCES FROM GIT-CONFIG> for details.)
 
-This is an object-oriented module using L<Any::Moose|Any::Moose>. All
+This is an object-oriented module using L<Moo|Moo>. All
 subroutines are object method calls.
 
 A few methods have parameters that are always used for the same purpose:

--- a/lib/Config/GitLike/Cascaded.pm
+++ b/lib/Config/GitLike/Cascaded.pm
@@ -1,17 +1,17 @@
 package Config::GitLike::Cascaded;
-use Any::Moose;
+use Moo;
 use Cwd;
 use File::Spec;
 
 extends 'Config::GitLike';
 
 has 'cascade' => (
-    default => 1,
+    default => sub { 1 },
     is => 'rw',
 );
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Config/GitLike/Git.pm
+++ b/lib/Config/GitLike/Git.pm
@@ -1,5 +1,5 @@
 package Config::GitLike::Git;
-use Any::Moose;
+use Moo;
 use strict;
 use warnings;
 
@@ -48,7 +48,7 @@ sub load_dirs {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/t/lib/TestConfig.pm
+++ b/t/lib/TestConfig.pm
@@ -1,12 +1,13 @@
 package TestConfig;
-use Any::Moose;
+use Moo;
+use MooX::Types::MooseLike::Base qw(Str);
 use File::Spec;
 extends 'Config::GitLike';
 
 has 'tmpdir' => (
     is => 'rw',
     required => 1,
-    isa => 'Str',
+    isa => Str,
 );
 
 # override these methods so:
@@ -57,7 +58,7 @@ sub burp {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 


### PR DESCRIPTION
I want to port Git::PurePerl Moo.
(ref. https://rt.cpan.org/Public/Bug/Display.html?id=73966)

But Git::PurePerl depends on Config-GitLike, using Any::Moose.

I propose switch to Moo.

Note. Any::Moose is deprecated. https://metacpan.org/module/Any::Moose
