### PR TITLE
Throw an error when get() is passed no section.

### DIFF
--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -654,6 +654,8 @@ sub canonical_case {
     my $self = shift;
     my ($key) = @_;
     my ($section, $subsection, $name) = _split_key($key);
+    die "No section given in key: $key\n" unless $section;
+
     return join( '.',
         grep { defined } (lc $section, $subsection, lc $name),
     );

--- a/t/casing.t
+++ b/t/casing.t
@@ -39,6 +39,10 @@ is $config->original_key( 'core.foobar' ), "core.FooBar",
 is $config->original_key( 'core.FOObar' ), "core.FooBar",
     "Find original case when asked in different case";
 
+eval { $config->get( key => 'core') };
+ok my $err = $@, 'Should get an error when no section passed to get().';
+like $err, qr/No section given in key: core/,
+    'The missing section error should be correct';
 
 my $other_filename = File::Spec->catfile( $config_dirname, 'other' );
 $config->set(


### PR DESCRIPTION
Reported in theory/sqitch#110. It was doing this:

```
t/sqitch config --get user
Use of uninitialized value $section in lc at lib/Config/GitLike.pm line 658.
```

But that is not what Git does:

```
> git config --get user
error: key does not contain a section: user
```

This patch makes Config::GitLike behave a bit more like Git in this respect.
