### PR TITLE
Fix for t/casing.t failure on mac os

### DIFF
--- a/t/casing.t
+++ b/t/casing.t
@@ -3,11 +3,12 @@ use warnings;
 
 use Test::More;
 use File::Spec;
+use Cwd;
 use File::Temp qw/tempdir/;
 use lib 't/lib';
 use TestConfig;
 
-my $config_dirname = tempdir( CLEANUP => !$ENV{CONFIG_GITLIKE_DEBUG} );
+my $config_dirname = Cwd::abs_path( tempdir( CLEANUP => !$ENV{CONFIG_GITLIKE_DEBUG} ) );
 my $config_filename = File::Spec->catfile( $config_dirname, 'config' );
 
 diag "config file is: $config_filename" if $ENV{TEST_VERBOSE};


### PR DESCRIPTION
The following test fails on mac os, where /var is a symlink to /private/var

```
 t/casing.t ............. 1/?
 #   Failed test 'Found definition from second file'
 #   at t/casing.t line 53.
 #          got: '/private/var/folders/zz/zyxvpxvq6csfxvn_n00026dc000jlb/T/5fRT_POw_o/other'
 #     expected: '/var/folders/zz/zyxvpxvq6csfxvn_n00026dc000jlb/T/5fRT_POw_o/other'
 # Looks like you failed 1 test of 19.
 t/casing.t ............. Dubious, test returned 1 (wstat 256, 0x100)
 Failed 1/19 subtests
```

The config filename is converted to an absolute path inside load_file, but the test
checks the original path. This changes the test to use the same call to Cwd::abs_path.
