### PR TITLE
problem in get_regexp() when filtering is used on keys with multiple values

### DIFF
--- a/lib/Config/GitLike.pm
+++ b/lib/Config/GitLike.pm
@@ -675,14 +675,26 @@ sub get_regexp {
         }
         elsif ($args{filter} =~ s/^!//) {
             for (keys %results) {
-                delete $results{$_} if defined $results{$_}
-                    and $results{$_} =~ m/$args{filter}/i;
+                my @values = ref $results{$_} ? @{$results{$_}} : $results{$_};
+                @values = grep { not defined or not m/$args{filter}/i } @values;
+                if (!@values) {
+                    delete $results{$_};
+                }
+                else {
+                    $results{$_} = @values > 1 ? \@values : $values[0];
+                }
             }
         }
         else {
             for (keys %results) {
-                delete $results{$_} if not defined $results{$_}
-                    or $results{$_} !~ m/$args{filter}/i;
+                my @values = ref $results{$_} ? @{$results{$_}} : $results{$_};
+                @values = grep { defined and m/$args{filter}/i } @values;
+                if (!@values) {
+                    delete $results{$_};
+                }
+                else {
+                    $results{$_} = @values > 1 ? \@values : $values[0];
+                }
             }
         }
     }

--- a/t/get_regexp_filter_multiple.t
+++ b/t/get_regexp_filter_multiple.t
@@ -1,0 +1,187 @@
+# tests that serve to expose a problem with the interaction of filtering and
+# multiple values in get_regexp() in Config::GitLike 1.16
+
+use strict;
+use warnings;
+
+use File::Copy;
+use Test::More tests => 30;
+use Test::Exception;
+use File::Spec;
+use File::Temp qw/tempdir/;
+use lib 't/lib';
+use TestConfig;
+
+# create an empty test directory in /tmp
+my $config_dirname = tempdir( CLEANUP => !$ENV{CONFIG_GITLIKE_DEBUG} );
+my $config_filename = File::Spec->catfile( $config_dirname, 'config' );
+
+diag "config file is: $config_filename" if $ENV{TEST_VERBOSE};
+
+my $config
+    = TestConfig->new( confname => 'config', tmpdir => $config_dirname );
+
+$config->burp(
+    '# foo
+[section]
+	b = off
+	b = on
+	exact = 0
+	inexact = 01
+	delicieux = true
+'
+);
+
+$config->load;
+
+# 'delicieux' has only 1 value
+is_deeply(
+    scalar $config->get_all( key => 'section.delicieux' ),
+    ['true'], 'get all values for key delicieux'
+);
+
+is_deeply(
+    scalar $config->get_all( key => 'section.delicieux', filter => 'true' ),
+    ['true'], 'get all values for key delicieux, filter by regexp'
+);
+
+is_deeply(
+    scalar $config->get_all( key => 'section.delicieux', filter => 'false' ),
+    [], 'get all values for key delicieux, filter by regexp "false"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.delicieux' ),
+    { 'section.delicieux' => 'true' }, 'get all values for key delicieux by regexp'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.delicieux', filter => 'true' ),
+    { 'section.delicieux' => 'true' }, 'get all values for key delicieux by regexp, filter by true'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.delicieux', filter => '!true' ),
+    {}, 'get all values for key delicieux by regexp, filter by !true'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.delicieux', filter => 'false' ),
+    {}, 'get all values for key delicieux by regexp, filter by false'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.delicieux', filter => '!false' ),
+    { 'section.delicieux' => 'true' }, 'get all values for key delicieux by regexp, filter by !false'
+);
+
+# 'b' has multiple values (2)
+is_deeply(
+    scalar $config->get_all( key => 'section.b' ),
+    ['off', 'on'], 'get all values for key b'
+);
+
+is_deeply(
+    scalar $config->get_all( key => 'section.b', filter => 'o' ),
+    ['off', 'on'], 'get all values for key b, filter by letter "o"'
+);
+
+is_deeply(
+    scalar $config->get_all( key => 'section.b', filter => 'n' ),
+    ['on'], 'get all values for key b, filter by letter "n"'
+);
+
+is_deeply(
+    scalar $config->get_all( key => 'section.b', filter => 'Q' ),
+    [], 'get all values for key b, filter by letter "Q"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by empty regex'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '.*' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by catch-all regex'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '^.*$' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by anchored catch-all regex'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => qr/(on|off)/ ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by regex on|off'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => qr/^(on|off)$/ ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by anchored regex on|off'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => 'o' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by letter "o"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => 'n' ),
+    { 'section.b' => 'on' }, 'get all values for key b by regexp, filter by letter "n"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => 'Q' ),
+    {}, 'get all values for key b by regexp, filter by letter "Q"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => 'ARRAY' ),
+    {}, 'get all values for key b by regexp, filter by word "ARRAY"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!' ),
+    {}, 'get all values for key b by regexp, filter by negated regex'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!.*' ),
+    {}, 'get all values for key b by regexp, filter by negated catch-all regex'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!(on|off)' ),
+    {}, 'get all values for key b by regexp, filter by "!(on|off)"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!on|off' ),
+    {}, 'get all values for key b by regexp, filter by "!on|off"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!good|bad' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by negated regex good|bad'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!o' ),
+    {}, 'get all values for key b by regexp, filter by "!o"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!n' ),
+    { 'section.b' => 'off' }, 'get all values for key b by regexp, filter by "!n"'
+);
+
+is_deeply(
+    scalar $config->get_regexp( key => 'section\.b', filter => '!ARRAY' ),
+    { 'section.b' => ['off', 'on'] }, 'get all values for key b by regexp, filter by "!ARRAY"'
+);


### PR DESCRIPTION
get_regexp() doesn't produce sensible results in Version 1.16 when filtering is used on keys with multiple values. I have added tests (in t/get_regexp_filter_multiple.t) that expose the problem. Basically, for keys with multiple values, the string rendition of an arrayref was being matched against the filter regex, instead of the individual values inside the arrayref. I have also attached a proposed solution.

Although I find that the semantics of get_regexp() are slightly inconsistent with those of get_all() (i.e., get_all returns an arrayref with one element for a key that happens to have one value, but get_regexp() will return a scalar value instead), I aimed for consistency with the original tests. Therefore, the hashref that is returned by get_regexp() will have

  (a) the key deleted if there are 0 values
  (b) a scalar value for that key if there is only 1 value
  (c) an arrayref if there is more than 1 value

Let me know what you think. If you like what I did, I would appreciate a release as soon as possible, because I would like to use this feature. If you're not happy, please let me know.

Best regards!
