### PR TITLE
Add failing tests for varying platform files.

### DIFF
--- a/t/dos.conf
+++ b/t/dos.conf
@@ -1,0 +1,6 @@
+[core]
+	engine = pg
+	top_dir = sql
+[deploy]
+	verify = true
+

--- a/t/mac.conf
+++ b/t/mac.conf
@@ -1,0 +1,1 @@
+[core]	engine = pg	top_dir = sql[deploy]	verify = true

--- a/t/platforms.t
+++ b/t/platforms.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Config::GitLike;
+use File::Spec;
+
+for my $platform (qw(unix dos mac)) {
+    my $config_filename = File::Spec->catfile('t', "$platform.conf");
+    ok my $data = Config::GitLike->load_file($config_filename),
+        "Load $platform config";
+    is_deeply $data, {
+        'core.engine' => 'pg',
+        'core.top_dir' => 'sql',
+        'deploy.verify' => 'true',
+    }, "Should have proper config for $platform file";
+}
+
+done_testing;

--- a/t/unix.conf
+++ b/t/unix.conf
@@ -1,0 +1,6 @@
+[core]
+	engine = pg
+	top_dir = sql
+[deploy]
+	verify = true
+


### PR DESCRIPTION
There are reported cases, such as theory/sqitch#338, where folks try to read a config
file written on one platform from another platform. That does not work. Here are some
tests to demonstrate the failures. I tried to fix it by adding a `s/[\r\n]+/\n/g` to
`_read_config`, but that broke other stuff. You might have to tweak the parser,
instead.