### PR TITLE
dir_file() does not work as documented

### DIFF
--- a/lib/Config/GitLike/Git.pm
+++ b/lib/Config/GitLike/Git.pm
@@ -49,7 +49,13 @@ sub load_dirs {
 
 sub dir_file {
     my $self = shift;
-    return ".git/config";
+    my $path = $self->is_git_dir(".");
+    if ((defined $path) and ($path ne "")) {
+	my($vol, $dirs, undef) = File::Spec->splitpath( $path, 1 );
+	my @dirs               = File::Spec->splitdir( $dirs );
+	$path = File::Spec->catfile( @dirs, "config");
+    }
+    return $path;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Config/GitLike/Git.pm
+++ b/lib/Config/GitLike/Git.pm
@@ -47,6 +47,11 @@ sub load_dirs {
     $self->load_file( File::Spec->catfile( $dir, "config" ) );
 }
 
+sub dir_file {
+    my $self = shift;
+    return ".git/config";
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moo;
 


### PR DESCRIPTION
The documentation claims it returned ".git/config", but it actually
returns ".gitconfig". This is particularly inconvenient when doing a
read/modify/write of one and the same configuration in place. The
filename parameter to set() is required, but the only way to get the
name of the config file which was read before (the dir_file() method)
returns the wrong file name.